### PR TITLE
Update requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,11 @@
     "GPL-3.0-only"
   ],
   "require": {
-    "php": ">=7.0",
-    "twig/twig": "^2.5"
+    "php": ">=7.1",
+    "twig/twig": "^2.5",
+    "oxid-esales/twig-theme": "^1.0",
+    "oxid-esales/twig-admin-theme": "^1.0",
+    "oxid-esales/oxideshop-ce": ">=6.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The component **has** to be used together with the theme packages, because the shops service is being overridden [here](https://github.com/OXID-eSales/twig-component/blob/master/services.yaml#L52) and [here](https://github.com/OXID-eSales/twig-component/blob/master/services.yaml#L53), after installation, which causes the framework to search for .html.twig files only.

Both themes require the component, which means that they are dependent on another.
Therefore the theme packages should be required in the component package.