### PR TITLE
Fix broken include_dynamic tag

### DIFF
--- a/src/Node/IncludeDynamicNode.php
+++ b/src/Node/IncludeDynamicNode.php
@@ -63,9 +63,13 @@ class IncludeDynamicNode extends IncludeNode
         $compiler->write("echo \$this");
         $compiler->raw("->extensions['" . IncludeExtension::class . "']");
         if ($this->hasNode('variables')) {
-            $compiler->raw("->renderForCache(\$parameters);\n");
+            $compiler->raw("->renderForCache(array_merge(\$parameters, ['file' => ");
+            $compiler->subcompile($this->getNode('expr'));
+            $compiler->raw("]));\n");
         } else {
-            $compiler->raw("->renderForCache([]);\n");
+            $compiler->raw("->renderForCache(['file' => ");
+            $compiler->subcompile($this->getNode('expr'));
+            $compiler->raw("]);\n");
         }
     }
 


### PR DESCRIPTION
The parameter "file" was not written to the <oxid_dynamic>-tag anymore.

**Example:**

Code from the Twig-Template:

```twig
{% include_dynamic "widget/dynscript.html.twig" %}
```

Generated <oxid_dynamic>-element inside the cache-file form the OXID content-cache before this change:

```html
<oxid_dynamic> </oxid_dynamic>
```

-> The included template is missing from the output because the method `\OxidEsales\EshopEnterprise\Core\Cache\DynamicContent\ContentCache::_processDynContent()` does not know what to do with this empty element.

And after the change:

```html
<oxid_dynamic> file='d2lkZ2V0L2R5bnNjcmlwdC5odG1sLnR3aWc='</oxid_dynamic>
```

-> The included template is (dynamicly) included again.